### PR TITLE
fix #1 - Group documents by folder

### DIFF
--- a/src/pickyadventurer.js
+++ b/src/pickyadventurer.js
@@ -153,7 +153,10 @@ class Picker extends HandlebarsApplicationMixin(ApplicationV2) {
       const config = CONFIG[docType];
       const cls = getDocumentClass(docType);
 
-      const tree = this.#buildTreeFor(docType, docs, allFolders);
+      const tree =
+        docType === "Folder"
+          ? this.#buildTreeForFolders(docs)
+          : this.#buildTreeFor(docType, docs, allFolders);
       console.log(`Tree for ${docType}:`, tree);
       // TODO use tree
 
@@ -251,6 +254,30 @@ class Picker extends HandlebarsApplicationMixin(ApplicationV2) {
     tree.entries = docs.filter((d) => !d.folder);
 
     return tree;
+  }
+
+  /**
+   * Special handling for folders, group by document type rather than the normal tree
+   */
+  #buildTreeForFolders(docs) {
+    // organize the folders by type
+    const byType = docs.reduce((obj, folder) => {
+      if (!obj[folder.type]) obj[folder.type] = [];
+      obj[folder.type].push(folder);
+      return obj;
+    }, {});
+
+    // make fake folders to group by type
+    const children = Object.entries(byType).map(([docType, folders]) => {
+      const cls = getDocumentClass(docType);
+      return {
+        folder: { name: game.i18n.localize(cls.metadata.labelPlural) },
+        children: [],
+        entries: folders,
+      };
+    });
+
+    return { folder: null, children, entries: [] };
   }
 
   /**

--- a/src/pickyadventurer.js
+++ b/src/pickyadventurer.js
@@ -187,15 +187,17 @@ class Picker extends HandlebarsApplicationMixin(ApplicationV2) {
     const createNode = (folder) => ({ folder, children: [], entries: [] });
     const fillFolder = (folder, depth) => {
       const node = createNode(folder);
+      const sort = folder.sorting === "a" ? Picker._sortAlpha : Picker._sortManual;
       // traverse the child folders
       if (depth <= CONST.FOLDER_MAX_DEPTH) {
         node.children = folders
           .filter((f) => f.folder === folder._id)
+          .sort(sort)
           .map((f) => fillFolder(f, depth + 1))
           .filter((node) => node !== null);
       }
       // find documents in this folder
-      node.entries = docs.filter((doc) => doc.folder === folder._id);
+      node.entries = docs.filter((doc) => doc.folder === folder._id).sort(sort);
       // only return node if it's not empty, we don't want to show empty folders
       return node.children.length || node.entries.length ? node : null;
     };
@@ -278,5 +280,17 @@ class Picker extends HandlebarsApplicationMixin(ApplicationV2) {
     // unselect each option
     const multiSelect = actionButton.closest("fieldset").querySelector("multi-select");
     Object.keys(multiSelect._choices).forEach((value) => multiSelect.unselect(value));
+  }
+
+  /**
+   * Utility functions
+   */
+
+  static _sortAlpha(a, b) {
+    return a.name.localeCompare(b.name, game.i18n.lang);
+  }
+
+  static _sortManual(a, b) {
+    return a.sort - b.sort;
   }
 }

--- a/templates/picker-part-list.hbs
+++ b/templates/picker-part-list.hbs
@@ -14,7 +14,6 @@
       <div class="form-group">
         <div class="form-fields">
           <multi-select name="{{../tab.id}}.{{type.id}}">
-            {{!-- {{selectOptions type.list valueAttr="id" labelAttr="name"}} --}}
             {{selectOptions type.options groups=type.groups}}
           </multi-select>
         </div>

--- a/templates/picker-part-list.hbs
+++ b/templates/picker-part-list.hbs
@@ -14,7 +14,8 @@
       <div class="form-group">
         <div class="form-fields">
           <multi-select name="{{../tab.id}}.{{type.id}}">
-            {{selectOptions type.list valueAttr="id" labelAttr="name"}}
+            {{!-- {{selectOptions type.list valueAttr="id" labelAttr="name"}} --}}
+            {{selectOptions type.options groups=type.groups}}
           </multi-select>
         </div>
       </div>


### PR DESCRIPTION
In the `<select>` elements, group the documents by folder to make them easier to find. It uses the Handlebars helper to add `<optgroup>` elements, but since there's no supported for nested groups this flattens the folders separated by an em-dash. There is also special handling of the the Folders type, where those are grouped by document type rather than their actual hierarchy. This also means we can sort the documents based on the folder settings too.